### PR TITLE
angular v1.3 support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,11 +6,11 @@
     "dist/angular-fontawesome.js"
   ],
   "dependencies": {
-    "angular": "~1.2",
+    "angular": "^1.2",
     "font-awesome": "~4"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2"
+    "angular-mocks": "^1.2"
   },
   "ignore": [
     ".jshintrc",


### PR DESCRIPTION
Hello, @fastfrwrd! Angular v1.3.0 was just released. And currently I can't run `bower install` w/o problems: it brings dependency conflict. Your package resolves `~1.2` to latest `1.2.x` and I have `1.3.0`. I think later others will face same thing too. I changed `~1.2` to `^1.2`, so it will be OK with angular `1.3.x`.

P.S.: if there is a way to limit only to 1.2.x and 1.3.x, that maybe would be more wise.
